### PR TITLE
Disable activities hack

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -50,7 +50,7 @@ class ReactionLight(commands.InteractionBot):
     def __init__(self):
         self.directory = os.path.dirname(os.path.realpath(__file__))
         self.config = parser.Config(self.directory)
-        self.activities = activity.Activities(f"{self.directory}/files/activities.csv")
+        #self.activities = activity.Activities(f"{self.directory}/files/activities.csv")
         self.db = database.Database(f"{self.directory}/files/reactionlight.db")
         self.version = version.get(self.directory)
         self.response = Response(self, f"{self.directory}/i18n", self.config.language)

--- a/bot.py
+++ b/bot.py
@@ -50,7 +50,7 @@ class ReactionLight(commands.InteractionBot):
     def __init__(self):
         self.directory = os.path.dirname(os.path.realpath(__file__))
         self.config = parser.Config(self.directory)
-        #self.activities = activity.Activities(f"{self.directory}/files/activities.csv")
+        # self.activities = activity.Activities(f"{self.directory}/files/activities.csv")
         self.db = database.Database(f"{self.directory}/files/reactionlight.db")
         self.version = version.get(self.directory)
         self.response = Response(self, f"{self.directory}/i18n", self.config.language)

--- a/cogs/settings.py
+++ b/cogs/settings.py
@@ -36,12 +36,12 @@ class Settings(commands.Cog):
         # pylint: disable=no-member
         self.maintain_presence.start()
 
-    @tasks.loop(seconds=30)
-    async def maintain_presence(self):
-        await self.bot.wait_until_ready()
-        # Loops through the activities specified in activities.csv
-        current_activity = self.bot.activities.get()
-        await self.bot.change_presence(activity=disnake.Game(name=current_activity))
+    # @tasks.loop(seconds=30)
+    # async def maintain_presence(self):
+    #     await self.bot.wait_until_ready()
+    #     # Loops through the activities specified in activities.csv
+    #     current_activity = self.bot.activities.get()
+    #     await self.bot.change_presence(activity=disnake.Game(name=current_activity))
 
     @commands.slash_command(name="settings")
     async def settings_group(self, inter):

--- a/cogs/settings.py
+++ b/cogs/settings.py
@@ -34,7 +34,7 @@ class Settings(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
         # pylint: disable=no-member
-        self.maintain_presence.start()
+        # self.maintain_presence.start()
 
     # @tasks.loop(seconds=30)
     # async def maintain_presence(self):


### PR DESCRIPTION
This pull request removes functionality related to maintaining bot presence based on activities defined in `activities.csv`. The changes focus on deprecating the use of the `activities` feature and the associated periodic task.

### Deprecation of `activities` feature:

* In `bot.py`, the initialization of `self.activities` (which loads activities from `activities.csv`) has been commented out, effectively disabling this feature.

* In `cogs/settings.py`, the `maintain_presence` task, which periodically updated the bot's presence using the `activities` feature, has been commented out. This includes both the task loop and its startup logic in the constructor.